### PR TITLE
boolean and port provider improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@ selinuxpolicy CHANGELOG
 
 This file is used to list changes made in each version of the selinuxpolicy cookbook.
 
+0.5.0
+-----
+
+- [Wade Peacock] - Added include_recipe to default.rb
+- [Wade Peacock] - Added RHEL 6 support
+- [Wade Peacock] - Rewrote :add,delete,modify,addormodify actions in port provider
+- [Wade Peacock] - Fixed whyrun support for port providers
+- [Wade Peacock] - Rewrote :set action in boolean provider
+- [Wade Peacock] - Remove :setpersist and added new attribute for persist to :set
+- [Wade Peacock] - Added detection to both port and boolean providers to silently handle SELINUX in disabled mode
+- [Wade Peacock] - Updated documentation
+
 0.4.0
 -----
 - [backlasher] - Fixed foodcritic errors

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ I made it because I needed some SELinux settings done, and the `execute`s starte
 
 Requirements
 ------------
-Needs an SELinux policy active (so its values can be managed).  
+Needs an SELinux policy active (so its values can be managed). Cookbook can be applied to system with SELINUX that is disabled, but it will silently pass. This allows you to include it in generic roles.
+
 Also requires SELinux's management tools, namely `semanage`, `setsebool` and `getsebool`.
 Tools are installed by the `selinux_policy::install` recipe (for RHEL/Debian and the like).
 
@@ -27,8 +28,9 @@ Using `setpersist` requires an active policy (so that the new value can be saved
 Attributes:
 
 * `name`: boolean's name. Defaults to resource name.
-* `value`: Its new value (`true`/`false`).
-* `force`: Use `setsebool` even if the current value agrees with the requested one.
+* `value`: `true`/`false`, which get transposed to `on`/`off`.
+* `persist`: Its value (`true`/`falue`), default `true`.
+* `force`: forcefully set the value even if it is correct.
 
 Example usage:
 
@@ -38,6 +40,17 @@ selinux_policy_boolean 'httpd_can_network_connect' do
     # Make sure nginx is started if this value was modified
     notifies :start,'service[nginx]', :immediate
 end
+
+# All options
+
+selinux_policy_boolean 'httpd_can_network_connect' do
+    value true
+    persist true
+    force false
+    # Make sure nginx is started if this value was modified
+    notifies :start,'service[nginx]', :immediate
+end
+
 ```
 
 **Note**: Due to ruby interperting `0` as `true`, using `value 0` is unwise.
@@ -56,7 +69,7 @@ Actions:
 Attributes:
 
 * `port`: The port in question, defaults to resource name.
-* `protocol`: `tcp`/`udp`.
+* `protocol`: `tcp`/`udp`. defaults to `tcp`
 * `secontext`: The SELinux context to assign the port to. Uneeded when using `delete`.
 
 Example usage:
@@ -78,7 +91,7 @@ Actions:
   * The module isn't currently present
   * `force` is enabled
   * The policy file has changed
-* `remove`: Removes a module 
+* `remove`: Removes a module
 
 Example usage:
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,5 +4,5 @@ maintainer_email 'nitz.raz@gmail.com'
 license          'GPL v2'
 description      'Manages SELinux policy components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '0.5.0'
 

--- a/providers/boolean.rb
+++ b/providers/boolean.rb
@@ -1,25 +1,63 @@
+#
+# Author:: Wade Peacock (wade.peacock@visioncritical.com)
+# Cookbook Name:: selinux_policy
+# Provider:: boolean
+#
+# Original Author:: backslasher
+# Original Cookbook Name:: selinux_policy
+# Original Provider:: boolean
+#
+
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
+
+action :set do
+  unless (@current_resource.exists) 
+    converge_by("Process set boolean - #{@new_resource}") do
+      # Convert true/false to 'on'/'off'
+      new_value = @new_resource.value ? 'on' : 'off'
+      cmd = "setsebool "
+      cmd += "-P " if @new_resource.persist
+      cmd += "#{@new_resource.name} #{new_value}"
+      shell_out(cmd)
+      @new_resource.updated_by_last_action(true)
+    end
+  end
+end
+
 # Support whyrun
 def whyrun_supported?
   true
 end
 
-use_inline_resources
-
-# Set for now, without persisting
-action :set do
-  set_sebool(false)
-end
-
-# Set and persist
-action :setpersist do
-  set_sebool(true)
-end
-
-def set_sebool(persist=false)
-  persist_string= persist ? '-P ':''
-  new_value= new_resource.state ? 'on' : 'off'
-  e = execute "selinux-setbool-#{new_resource.name}-#{new_value}" do
-    command "/usr/sbin/setsebool #{persist_string} #{new_resource.name} #{new_value}"
-    not_if "/usr/sbin/getsebool #{new_resource.name} | grep '#{new_value}$' >/dev/null" if !new_resource.force
+def load_current_resource
+  @current_resource = Chef::Resource::SelinuxPolicyBoolean.new(@new_resource.name)
+  @current_resource.name(@new_resource.name)
+  # Get Enforcement level of SELINUX
+  cmd = shell_out("getenforce")
+  if ( cmd.stdout =~ /disabled/i )
+    @current_resource.disabled = true
+  else
+    @current_resource.disabled = false
+  end
+  # Unless SELINUX is disabled
+  unless @current_resource.disabled
+    cmd = shell_out("getsebool #{@new_resource.name}") 
+    # Convert true/false to 'on'/'off'
+    new_value = @new_resource.value ? 'on' : 'off'
+    unless cmd.stdout =~ /#{new_value}$/
+      @current_resource.exists = false
+    else
+      # Set to exists to false if force set to true
+      unless @new_resource.force
+        @current_resource.exists = true
+      else
+        @current_resource.exists = false
+      end
+    end
+  else
+    # Flag resource as correct if SELINUX is disabled (why would you?)
+    @current_resource.exists = true
+    Chef::Log.warn("SELINUX is disabled, skipping")
   end
 end

--- a/providers/port.rb
+++ b/providers/port.rb
@@ -1,41 +1,112 @@
+#
+# Author:: Wade Peacock (wade.peacock@visioncritical.com)
+# Cookbook Name:: selinux_policy
+# Provider:: port
+#
+# Original Author:: backslasher
+# Original Cookbook Name:: selinux_policy
+# Original Provider:: port
+#
+
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
+
+action :delete do
+  if @current_resource.exists && @current_resource.match
+    converge_by("Process deletion of port - #{@new_resource}") do
+      cmd = shell_out("semanage port -d -t #{@new_resource.secontext} -p #{@new_resource.protocol} #{@new_resource.port}")
+      # Need to add error support for attempts to remove ports defined by a policy
+      @new_resource.updated_by_last_action(true)
+    end
+  end
+end
+
+action :add do
+  unless (@current_resource.exists && @current_resource.match) 
+    converge_by("Process addition of port - #{@new_resource}") do
+      cmd = shell_out("semanage port -a -t #{@new_resource.secontext} -p #{@new_resource.protocol} #{@new_resource.port}")
+      @new_resource.updated_by_last_action(true)
+    end
+  else
+    unless (@current_resource.exists && @current_resource.match)  
+      Chef::Log.info("Port is already assigned not another secontext - use :modify action")
+    end
+  end
+end
+
+action :modify do
+  unless ( @current_resource.exists && @current_resource.match )
+    converge_by("Process reassignment of port - #{@new_resource}") do
+      cmd = shell_out("semanage port -m -t #{@new_resource.secontext} -p #{@new_resource.protocol} #{@new_resource.port}")
+      @new_resource.updated_by_last_action(true)
+    end
+  end
+end
+
+action :addormodify do
+  unless (@current_resource.exists && !@current_resource.match) 
+    converge_by("Process addition of port - #{@new_resource}") do
+      cmd = shell_out("semanage port -a -t #{@new_resource.secontext} -p #{@new_resource.protocol} #{@new_resource.port}")
+      @new_resource.updated_by_last_action(true)
+    end
+  else
+    converge_by("Process reassignment of port - #{@new_resource}") do
+      cmd = shell_out("semanage port -m -t #{@new_resource.secontext} -p #{@new_resource.protocol} #{@new_resource.port}")
+      @new_resource.updated_by_last_action(true)
+    end
+  end
+end
+
 # Support whyrun
 def whyrun_supported?
   true
 end
 
-use_inline_resources
-
-# Create if doesn't exist, do not touch if port is already registered (even under different type)
-action :add do
-  execute "selinux-port-#{new_resource.port}-add" do
-    command "/usr/sbin/semanage port -a -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}"
-    not_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null"
-  end
-end
-
-# Delete if exists
-action :delete do
-  execute "selinux-port-#{new_resource.port}-delete" do
-    command "/usr/sbin/semanage port -d -p #{new_resource.protocol} #{new_resource.port}"
-    only_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null"
-  end
-end
-
-action :modify do
-  execute "selinux-port-#{new_resource.port}-modify" do
-    command "/usr/sbin/semanage port -m -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}"
-  end
-end
-
-action :addormodify do
-  execute "selinux-port-#{new_resource.port}-addormodify" do
-    command <<-EOT
-  if /usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null; then
-    /usr/sbin/semanage port -m -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}
+def load_current_resource
+  @current_resource = Chef::Resource::SelinuxPolicyPort.new(@new_resource.name)
+  @current_resource.name(@new_resource.name)
+  # Get Enforcement level of SELINUX
+  cmd = shell_out("getenforce")
+  if ( cmd.stdout =~ /disabled/i )
+    @current_resource.disabled = true
   else
-    /usr/sbin/semanage port -a -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}
-  fi
-  EOT
-  not_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.secontext}\\s+#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null"
+    @current_resource.disabled = false
+  end
+  # Unless SELINUX is disabled
+  unless @current_resource.disabled
+    cmd = shell_out("semanage port -l | grep #{@new_resource.protocol}") 
+    # Remove commas
+    cmd_array = cmd.stdout.gsub(/,/,'')
+    # Split on spaces into an array
+    cmd_array = cmd_array.split(" ")
+    unless cmd_array.include? @new_resource.port
+      @current_resource.exists = false
+    else
+      @current_resource.exists = true
+    end
+    if @current_resource.exists
+      cmd = shell_out("semanage port -l |  grep #{@new_resource.secontext} | grep #{@new_resource.protocol}")
+      # Unless SELINUX is disabled
+      if ( cmd.stdout.empty? )
+        @current_resource.match = false
+      else
+        # Remove commas
+        cmd_array = cmd.stdout.gsub(/,/,'')
+        # Split on spaces into an array
+        cmd_array = cmd_array.split(" ")
+        unless cmd_array.include? @new_resource.port
+          @current_resource.match = false
+        else
+          @current_resource.match = true
+        end
+      end
+    else
+        @current_resource.match = false
+    end
+  else
+    # Flag resource as correct if SELINUX is disabled (why would you?)
+    @current_resource.exists = true
+    @current_resource.match = true
+    Chef::Log.warn("SELINUX is disabled, skipping")
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,4 +6,6 @@
 #
 # GPLv2
 #
-# Nothing's here!
+#
+
+include_recipe "selinux_policy::install"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -6,13 +6,25 @@
 #
 # GPLv2
 #
+
 case node['platform_family']
   when "debian"
     pkgs = [ 'policycoreutils', 'selinux-policy-dev', 'make' ]
   when "rhel"
-    pkgs = [ 'policycoreutils-python', 'selinux-policy', 'make' ]
-  else
-    raise 'Uknown distro, cannot determine required package names'
+    # Handle RHEL 5 vs 6
+    case node['platform_version'].to_i.floor
+      when 5
+        # This pulls in all dependencies
+        pkgs = [ 'policycoreutils', 'selinux-policy', 'make' ]
+      when 6
+        # This pulls in all dependencies
+        pkgs = [ 'policycoreutils-python', 'selinux-policy', 'make' ]
+      end
+  else raise 'Uknown distro, cannot determine required package name'
 end
 
-pkgs.each{|p|package p}
+pkgs.each do | pkg | 
+  package pkg do
+    action :install
+  end
+end

--- a/resources/boolean.rb
+++ b/resources/boolean.rb
@@ -1,9 +1,20 @@
+#
+# Author:: Wade Peacock (wade.peacock@visioncritical.com)
+# Cookbook Name:: selinux_policy
+# Resource:: boolean
+#
+# Original Author:: backslasher
+# Original Cookbook Name:: selinux_policy
+# Original Resource:: boolean
+#
 # A resource for managing SELinux Booleans
 
-actions :set,:setpersist
-default_action :setpersist
+actions :set
+default_action :set
 
 attribute :name, :kind_of => String, :name_attribute => true
 attribute :value, :kind_of => [ TrueClass, FalseClass ]
+attribute :persist, :kind_of => [ TrueClass, FalseClass ], :default => true
 attribute :force, :kind_of => [ TrueClass, FalseClass ], :default => false
 
+attr_accessor :exists, :disabled

--- a/resources/port.rb
+++ b/resources/port.rb
@@ -1,9 +1,21 @@
+#
+# Author:: Wade Peacock (wade.peacock@visioncritical.com)
+# Cookbook Name:: selinux_policy
+# Resource:: port
+#
+# Original Author:: backslasher
+# Original Cookbook Name:: selinux_policy
+# Original Resource:: port
+#
 # Manages a port assignment in SELinux
 # See http://docs.fedoraproject.org/en-US/Fedora/13/html/SELinux_FAQ/index.html#id3715134
 
-actions :add, :delete, :modify, :addormodify
-default_action :addormodify
+actions :add, :delete, :reassign, :modify, :addormodify
+default_action :add
 
 attribute :port, :kind_of => Integer, :name_attribute => true
-attribute :protocol, :kind_of => String, :equal_to => ['tcp', 'udp']
+attribute :protocol, :kind_of => String, :equal_to => ['tcp', 'udp'], :default => 'tcp'
 attribute :secontext, :kind_of => String
+
+attr_accessor :exists, :disabled, :match
+


### PR DESCRIPTION
Merge documentation changes
improved why_run? support for boolean and port providers.
Slight change to "persist" changed to attribute rather than a separate action
Handles SELinux gracefully when it is disabled.
Tried to keep as much backwards compatibility as possible.
Added include_recipe to default recipe.
Added rhel-5 vs rhel-6 support.