### PR TITLE
Fix port matching for multiple port cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+
+.idea/

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source "https://supermarket.getchef.com"
+source "https://supermarket.chef.io"
 
 metadata
 

--- a/providers/port.rb
+++ b/providers/port.rb
@@ -33,7 +33,7 @@ end
 action :addormodify do
   execute "selinux-port-#{new_resource.port}-addormodify" do
     command <<-EOT
-    if /usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null; then
+    if /usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}.*#{new_resource.port}'>/dev/null; then
       /usr/sbin/semanage port -m -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}
     else
       /usr/sbin/semanage port -a -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}

--- a/providers/port.rb
+++ b/providers/port.rb
@@ -9,7 +9,7 @@ use_inline_resources
 action :add do
   execute "selinux-port-#{new_resource.port}-add" do
     command "/usr/sbin/semanage port -a -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}"
-    not_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null"
+    not_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}.*#{new_resource.port}'>/dev/null"
     only_if {use_selinux}
   end
 end
@@ -18,7 +18,7 @@ end
 action :delete do
   execute "selinux-port-#{new_resource.port}-delete" do
     command "/usr/sbin/semanage port -d -p #{new_resource.protocol} #{new_resource.port}"
-    only_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null"
+    only_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}.*#{new_resource.port}'>/dev/null"
     only_if {use_selinux}
   end
 end
@@ -39,7 +39,7 @@ action :addormodify do
       /usr/sbin/semanage port -a -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}
     fi
     EOT
-    not_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.secontext}\\s+#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null"
+    not_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.secontext}.*#{new_resource.protocol}.*#{new_resource.port}'>/dev/null"
     only_if {use_selinux}
   end
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -17,10 +17,10 @@ case node['platform_family']
       when 6
         pkgs = [ 'policycoreutils-python', 'selinux-policy', 'make' ]
       else
-        raise 'Uknown version of RHEL/derivative, cannot determine required package names'
+        raise 'Unknown version of RHEL/derivative, cannot determine required package names'
     end
   else
-    raise 'Uknown distro, cannot determine required package names'
+    raise 'Unknown distro, cannot determine required package names'
 end
 
 pkgs.each{|p|package p}


### PR DESCRIPTION
The current \\s in the port matching grep is too restrictive, for
example in the case of mysql selinux semanage port rules has the
following entry:

mysqld_port_t                  tcp      1186, 3306, 63132-63164

grep -P '#{new_resource.protocol}\\s+#{new_resource.port}' will never
match causing all operations to fail.

Fixed a minor typo in the install.rb error message and updated
supermarket reference to chef.io