### PR TITLE
Support Chef 11.8

### DIFF
--- a/libraries/helper-disabled.rb
+++ b/libraries/helper-disabled.rb
@@ -2,7 +2,8 @@
 # Library: helper-disabled
 # 2015, GPLv2, Nitzan Raz (http://backslasher.net)
 
-include 'Chef::Mixin::ShellOut'
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
 
 class Chef
   class Provider

--- a/libraries/helper-disabled.rb
+++ b/libraries/helper-disabled.rb
@@ -2,6 +2,8 @@
 # Library: helper-disabled
 # 2015, GPLv2, Nitzan Raz (http://backslasher.net)
 
+include 'Chef::Mixin::ShellOut'
+
 class Chef
   class Provider
     # Checks if SELinux is disabled and whether we're allowed to run when disabled

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'nitz.raz@gmail.com'
 license          'GPL v2'
 description      'Manages SELinux policy components'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.6.1'
+version          '0.6.2'
 
 attribute 'selinux_policy',
   :display_name => 'SELinux Policy',


### PR DESCRIPTION
Fixes issue #7 for our usages.

Further verification can be made in test kitchen by specifying the chef version in `.kitchen.yml`, though I have not done this for this PR.