### PR TITLE
Test Kitchen for Chef 11 and 12

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,21 +9,13 @@ platforms:
   - name: centos-6.6-chef-12
     driver:
       box: opscode-centos-6.6
+      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
     provisioner:
       require_chef_omnibus: 12.2.1
   - name: centos-6.6-chef-11
     driver:
       box: opscode-centos-6.6
-    provisioner:
-      require_chef_omnibus: 11.18.6
-  - name: ubuntu-12.04-chef-12
-    driver:
-      box: opscode-ubuntu-12.04
-    provisioner:
-      require_chef_omnibus: 12.2.1
-  - name: ubuntu-12.04-chef-11
-    driver:
-      box: opscode-ubuntu-12.04
+      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
     provisioner:
       require_chef_omnibus: 11.18.6
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,14 +3,33 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_solo
+  name: chef_zero
 
 platforms:
-  - name: ubuntu-12.04
-  - name: centos-6.4
+  - name: centos-6.6-chef-12
+    driver:
+      box: opscode-centos-6.6
+    provisioner:
+      require_chef_omnibus: 12.2.1
+  - name: centos-6.6-chef-11
+    driver:
+      box: opscode-centos-6.6
+    provisioner:
+      require_chef_omnibus: 11.18.6
+  - name: ubuntu-12.04-chef-12
+    driver:
+      box: opscode-ubuntu-12.04
+    provisioner:
+      require_chef_omnibus: 12.2.1
+  - name: ubuntu-12.04-chef-11
+    driver:
+      box: opscode-ubuntu-12.04
+    provisioner:
+      require_chef_omnibus: 11.18.6
 
 suites:
   - name: default
     run_list:
-      - recipe[selinux_policy::default]
+      - recipe[selinux::default]
+      - recipe[selinux_policy_test::default]
     attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,8 @@
 source "https://supermarket.getchef.com"
 
 metadata
+
+group :integration do
+  cookbook 'selinux', '~> 0.9.0'
+  cookbook 'selinux_policy_test', :path => './test/cookbooks/selinux_policy_test'
+end

--- a/test/cookbooks/selinux_policy_test/.gitignore
+++ b/test/cookbooks/selinux_policy_test/.gitignore
@@ -1,0 +1,16 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/test/cookbooks/selinux_policy_test/Berksfile
+++ b/test/cookbooks/selinux_policy_test/Berksfile
@@ -1,0 +1,3 @@
+source "https://supermarket.chef.io"
+
+metadata

--- a/test/cookbooks/selinux_policy_test/README.md
+++ b/test/cookbooks/selinux_policy_test/README.md
@@ -1,0 +1,4 @@
+# selinux_policy_test
+
+TODO: Enter the cookbook description here.
+

--- a/test/cookbooks/selinux_policy_test/README.md
+++ b/test/cookbooks/selinux_policy_test/README.md
@@ -1,4 +1,4 @@
 # selinux_policy_test
 
-TODO: Enter the cookbook description here.
+Wrapper cookbook to test selinux_policy LWRPs in Test Kitchen.
 

--- a/test/cookbooks/selinux_policy_test/chefignore
+++ b/test/cookbooks/selinux_policy_test/chefignore
@@ -1,0 +1,95 @@
+# Put files/directories that should be ignored in this file when uploading
+# or sharing to the community site.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+Guardfile
+Procfile
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Cookbooks #
+#############
+CONTRIBUTING
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile
+
+# Travis #
+##########
+.travis.yml

--- a/test/cookbooks/selinux_policy_test/metadata.rb
+++ b/test/cookbooks/selinux_policy_test/metadata.rb
@@ -1,0 +1,10 @@
+name             'selinux_policy_test'
+maintainer       'Kieren Evans'
+maintainer_email 'git@kle.me'
+license          'GPL v2'
+description      'Wrapper cookbook to test selinux_policy LWRPs'
+long_description 'Wrapper cookbook to test selinux_policy LWRPs'
+version          '0.1.0'
+
+depends          'selinux', '~> 0.9.0'
+depends          'selinux_policy'

--- a/test/cookbooks/selinux_policy_test/recipes/default.rb
+++ b/test/cookbooks/selinux_policy_test/recipes/default.rb
@@ -1,0 +1,15 @@
+#
+# Cookbook Name:: selinux_policy_test
+# Recipe:: default
+#
+# Copyright 2014, Kieren Evans
+#
+# GPLv2
+
+include_recipe 'selinux::enforcing'
+include_recipe 'selinux_policy::install'
+
+selinux_policy_port '1080' do
+  protocol 'tcp'
+  secontext 'http_port_t'
+end


### PR DESCRIPTION
Run `kitchen test` to converge two Centos 6.6 VMs - one with chef 11 and one with chef 12.

Unfortunately I've had to remove the ubuntu lines from the kitchen.yml as the Ubuntu VMs that are fetched from Chef's Bento repo do not have selinux enabled by default. With selinux disabled, it requires a reboot to enable and I'm not sure how to accomplish that.