### PR TITLE
Extend kitchen to test CentOS 7

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,18 +6,24 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-6.6-chef-12
-    driver:
-      box: opscode-centos-6.6
-      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
-    provisioner:
-      require_chef_omnibus: 12.2.1
   - name: centos-6.6-chef-11
     driver:
       box: opscode-centos-6.6
       box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
     provisioner:
       require_chef_omnibus: 11.18.6
+  - name: centos-6.6-chef-latest
+    driver:
+      box: opscode-centos-6.6
+      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.6_chef-provisionerless.box
+    provisioner:
+      require_chef_omnibus: latest
+  - name: centos-7.0-chef-latest
+    driver:
+      box: opscode-centos-7.0
+      box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box
+    provisioner:
+      require_chef_omnibus: latest
 
 suites:
   - name: default


### PR DESCRIPTION
And modify tests to test latest chef, except for 1 instance of 11 on
CentOS 6.6