### PR TITLE
Move helpers into a cookbook-specific module

### DIFF
--- a/libraries/helper-disabled.rb
+++ b/libraries/helper-disabled.rb
@@ -6,15 +6,17 @@ require 'chef/mixin/shell_out'
 include Chef::Mixin::ShellOut
 
 class Chef
-  class Provider
-    # Checks if SELinux is disabled and whether we're allowed to run when disabled
-    def use_selinux
-      selinux_disabled= (shell_out!("getenforce").stdout =~ /disabled/i)
-      allowed_disabled=node['selinux_policy']['allow_disabled']
-      # return false only when SELinux is disabled and it's allowed
-      return_val=!(selinux_disabled && allowed_disabled)
-      Chef::Log.warn('SELinux is disabled, skipping') if !return_val
-      return return_val
+  module SELinuxPolicy
+    module Helpers
+      # Checks if SELinux is disabled and whether we're allowed to run when disabled
+      def use_selinux
+        selinux_disabled= (shell_out!("getenforce").stdout =~ /disabled/i)
+        allowed_disabled=node['selinux_policy']['allow_disabled']
+        # return false only when SELinux is disabled and it's allowed
+        return_val=!(selinux_disabled && allowed_disabled)
+        Chef::Log.warn('SELinux is disabled, skipping') if !return_val
+        return return_val
+      end
     end
   end
 end

--- a/libraries/helper-restorecon.rb
+++ b/libraries/helper-restorecon.rb
@@ -3,17 +3,19 @@
 # 2015, GPLv2, Joerg Herzinger (www.bytesource.net)
 
 class Chef
-  class Provider
-    # Returns the system command for restorecon
-    def restorecon(file_spec)
-      path = file_spec.to_s.sub(/\\/,'') # Remove backslashes
-      return "restorecon #{path}" if ::File.exist?(path) # Return if it's not a regular expression
-      path.count('/').times do
-        path = ::File.dirname(path) # Splits at last '/' and returns front part
-        break if ::File.directory?(path)
+  module SELinuxPolicy
+    module Helpers
+      # Returns the system command for restorecon
+      def restorecon(file_spec)
+        path = file_spec.to_s.sub(/\\/,'') # Remove backslashes
+        return "restorecon #{path}" if ::File.exist?(path) # Return if it's not a regular expression
+        path.count('/').times do
+          path = ::File.dirname(path) # Splits at last '/' and returns front part
+          break if ::File.directory?(path)
+        end
+        # This will restore the selinux file context recursively.
+        return "restorecon -R #{path}"
       end
-      # This will restore the selinux file context recursively.
-      return "restorecon -R #{path}"
     end
   end
 end

--- a/providers/boolean.rb
+++ b/providers/boolean.rb
@@ -1,3 +1,5 @@
+include Chef::SELinuxPolicy::Helpers
+
 # Support whyrun
 def whyrun_supported?
   true

--- a/providers/fcontext.rb
+++ b/providers/fcontext.rb
@@ -1,3 +1,5 @@
+include Chef::SELinuxPolicy::Helpers
+
 # Support whyrun
 def whyrun_supported?
   true

--- a/providers/module.rb
+++ b/providers/module.rb
@@ -1,3 +1,5 @@
+include Chef::SELinuxPolicy::Helpers
+
 # Support whyrun
 def whyrun_supported?
   true

--- a/providers/permissive.rb
+++ b/providers/permissive.rb
@@ -1,3 +1,5 @@
+include Chef::SELinuxPolicy::Helpers
+
 # Support whyrun
 def whyrun_supported?
   true

--- a/providers/port.rb
+++ b/providers/port.rb
@@ -1,3 +1,5 @@
+include Chef::SELinuxPolicy::Helpers
+
 # Support whyrun
 def whyrun_supported?
   true


### PR DESCRIPTION
Continuing the discussion from #22, these changes fulfil the primary objective of not defining methods directly in `Chef::Provider`, which is bad practise. Note that I haven't changed the body of the helper methods. You can see this easily if you diff with `--ignore-all-space`.

In terms of the secondary objective, I did not mean that you should add another recipe to this cookbook. Let me explain using the situation I am facing.

I have been revamping the chef-errbit community cookbook. This needs to work on platforms that do or do not feature SELinux. I can use the resources directly in a recipe and I know they will do nothing when SELinux is disabled because of the use_selinux check. However, there were two problems.

Platforms with SELinux enabled might not have the necessary packages installed. This is particularly true if you need to create a new module as the devel package containing the Makefile is not installed by default. I could add `include_recipe 'selinux_policy::install'` but then it would install these packages for all platforms, not just the ones with SELinux enabled. I would therefore like to make this conditional on use_selinux and this pull request makes that possible.

```ruby
extend SELinuxPolicy::Helpers
include_recipe 'selinux_policy::install' if use_selinux
```

I also had to fix the use_selinux check so that it doesn't blow up if getenforce is not available.