### PR TITLE
Update port rule to allow parsing of lists and ranges of ports

### DIFF
--- a/libraries/helper-portallowed.rb
+++ b/libraries/helper-portallowed.rb
@@ -1,0 +1,40 @@
+# Cookbook: selinux_policy
+# Library: helper-disabled
+# 2015, GPLv2, Neil Duff-Howie
+
+require 'chef/mixin/shell_out'
+include Chef::Mixin::ShellOut
+
+class Chef
+  module SELinuxPolicy
+    module Helpers
+      # return true if the supplied protocol/port is allowed by selinux for the context
+      def port_allowed?(context, protocol, port)
+        Chef::Log.debug("port_allowed? Querying:  #{context||'any'}:#{protocol} - #{port}")
+
+        port = port.to_i
+
+        return true unless use_selinux
+
+        list = shell_out!('semanage', 'port', '-l')
+
+        list.stdout.each_line do |line|
+          next unless line =~ /^([^\s]+)\s+(udp|tcp)\s+([0-9][0-9\s,-]*)/
+          next unless (context.nil? || $1 == context) && $2 == protocol
+
+          ports = $3
+
+          Chef::Log.debug("Current port configuration for #{context||'any'}:#{protocol} - #{ports}")
+
+          # handle, e.g. searching for '10005' in the following entry:
+          # http_cache_port_t              tcp      8080, 8118, 8123, 10001-10010
+          return true if ports.split(/,\s*/).detect do |p|
+            p.to_i == port || (p =~ /^(\d+)-(\d+)$/ && ($1.to_i..$2.to_i).include?(port))
+          end
+        end
+
+        false
+      end
+    end
+  end
+end

--- a/providers/port.rb
+++ b/providers/port.rb
@@ -11,7 +11,7 @@ use_inline_resources
 action :add do
   execute "selinux-port-#{new_resource.port}-add" do
     command "/usr/sbin/semanage port -a -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}"
-    not_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null"
+    not_if {port_allowed?(new_resource.secontext, new_resource.protocol, new_resource.port)}
     only_if {use_selinux}
   end
 end
@@ -20,7 +20,7 @@ end
 action :delete do
   execute "selinux-port-#{new_resource.port}-delete" do
     command "/usr/sbin/semanage port -d -p #{new_resource.protocol} #{new_resource.port}"
-    only_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null"
+    only_if {port_allowed?(new_resource.secontext, new_resource.protocol, new_resource.port)}
     only_if {use_selinux}
   end
 end
@@ -33,15 +33,21 @@ action :modify do
 end
 
 action :addormodify do
-  execute "selinux-port-#{new_resource.port}-addormodify" do
-    command <<-EOT
-    if /usr/sbin/semanage port -l | grep -P '#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null; then
-      /usr/sbin/semanage port -m -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}
-    else
-      /usr/sbin/semanage port -a -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}
-    fi
-    EOT
-    not_if "/usr/sbin/semanage port -l | grep -P '#{new_resource.secontext}\\s+#{new_resource.protocol}\\s+#{new_resource.port}'>/dev/null"
+  # add or modify based on whether or not any other context has that port open
+  # note this is currently quite inefficient because we're repeating semanage commands 
+  execute "selinux-port-#{new_resource.port}-add" do
+    command "/usr/sbin/semanage port -a -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}"
+    not_if {port_allowed?(nil, new_resource.protocol, new_resource.port)}
+    not_if {port_allowed?(new_resource.secontext, new_resource.protocol, new_resource.port)}
     only_if {use_selinux}
   end
+
+  execute "selinux-port-#{new_resource.port}-modify" do
+    command "/usr/sbin/semanage port -m -t #{new_resource.secontext} -p #{new_resource.protocol} #{new_resource.port}"
+    only_if {port_allowed?(nil, new_resource.protocol, new_resource.port)}
+    not_if {port_allowed?(new_resource.secontext, new_resource.protocol, new_resource.port)}
+    only_if {use_selinux}
+  end
+
 end
+


### PR DESCRIPTION
On CentOS 7, 'semanage port -l' produces condensed results like:
  http_cache_port_t              tcp      8080, 8118, 8123, 10001-10010

I've ported some code from an internal cookbook that parses this to detect if the target port is within the list of ports and ranges.
