### PR TITLE
Fix the resource attribute name

### DIFF
--- a/providers/boolean.rb
+++ b/providers/boolean.rb
@@ -19,7 +19,7 @@ end
 
 def set_sebool(persist=false)
   persist_string= persist ? '-P ':''
-  new_value= new_resource.state ? 'on' : 'off'
+  new_value= new_resource.value ? 'on' : 'off'
   e = execute "selinux-setbool-#{new_resource.name}-#{new_value}" do
     command "/usr/sbin/setsebool #{persist_string} #{new_resource.name} #{new_value}"
     not_if "/usr/sbin/getsebool #{new_resource.name} | grep '#{new_value}$' >/dev/null" if !new_resource.force

--- a/spec/boolean_spec.rb
+++ b/spec/boolean_spec.rb
@@ -1,0 +1,39 @@
+require 'chefspec'
+
+module ChefSpec
+  class SoloRunner
+    def converge_dsl(*recipes,&block)
+      cookbook_name = 'imaginary'
+      recipe_name = 'temp'
+      converge(*recipes){
+        recipe = Chef::Recipe.new(cookbook_name, recipe_name, @run_context)
+        recipe.instance_eval(&block)
+      }
+    end
+  end
+end
+
+
+describe 'selinux_policy boolean' do
+
+  let :chef_run do
+    ChefSpec::SoloRunner.new(step_into: ['selinux_policy_boolean']).converge_dsl('selinux_policy') do
+      node.override['selinux_policy']['allow_disabled'] = false
+      selinux_policy_boolean 'httpd_can_network_connect_db' do
+        value true
+      end
+      selinux_policy_boolean 'nagios_run_sudo' do
+        value false
+      end
+    end
+  end
+
+  describe 'SetAndPersist' do
+    it 'when value does not match' do
+      stub_command("/usr/sbin/getsebool httpd_can_network_connect_db | grep 'on$' >/dev/null").and_return(false)
+      stub_command("/usr/sbin/getsebool nagios_run_sudo | grep 'off$' >/dev/null").and_return(false)
+      expect(chef_run).to run_execute('selinux-setbool-httpd_can_network_connect_db-on')
+      expect(chef_run).to run_execute('selinux-setbool-nagios_run_sudo-off')
+    end
+  end
+end


### PR DESCRIPTION
The wrong name of the attribute is used here. Chef::Resource#state is
the alias to the Chef::Resource#state_for_resource_reporter method which
renders hash of all defined resource attributes with their values.
chef/chef@51cfbdc#L506
The correct attribute name is #value which is defined here
https://github.com/BackSlasher/chef-selinuxpolicy/blob/4d46d117033229cae35d8b13e43ae4cb19ded768/resources/boolean.rb#L7