### PR TITLE
Don't depend on yum cookbook as fixing Fedora is not our concern

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,6 +33,7 @@ suites:
       - fedora-23
   - name: broken_selinux
     run_list:
+      - recipe[yum::dnf_yum_compat]
       - recipe[selinux_policy_test::setup]
       - recipe[selinux_policy_test::single_port]
       - recipe[selinux_policy_test::twice_port]

--- a/Berksfile
+++ b/Berksfile
@@ -5,4 +5,5 @@ metadata
 group :integration do
   cookbook 'selinux', '~> 0.9.0'
   cookbook 'selinux_policy_test', :path => './test/cookbooks/selinux_policy_test'
+  cookbook 'yum', '~> 3.9'
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,5 +16,3 @@ supports 'centos'
 supports 'fedora'
 supports 'ubuntu'
 supports 'debian'
-
-depends 'yum', '~> 3.9.0'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -25,7 +25,6 @@ case node['platform_family']
     end
   when "fedora"
     pkgs = [ 'policycoreutils-python', 'selinux-policy-devel', 'setools-console', 'make' ]
-    include_recipe 'yum::dnf_yum_compat'
   else
     raise 'Unknown distro, cannot determine required package names'
 end


### PR DESCRIPTION
The yum cookbook suggests that end users should add fedora_yum_compat to their own run lists. We can continue to support Fedora under Kitchen by adding yum to the Berksfile instead.

Fixes #39.